### PR TITLE
changed return to categories

### DIFF
--- a/limeify-be/Endpoints/CategoryEndpoints.cs
+++ b/limeify-be/Endpoints/CategoryEndpoints.cs
@@ -7,7 +7,7 @@
             // get all categories
             app.MapGet("/api/categories", (LimeifyDbContext db) =>
             {
-                return db.Genres.ToList();
+                return db.Categories.ToList();
             });
         }
     }


### PR DESCRIPTION
## Description
In the categories endpoint, I corrected the return value to categories instead of genres.

## Motivation and Context
This change allows the add playlist dropdown to show categories instead of genres.

## How Can This Be Tested?
Run app -> Add Playlist -> check categories dropdown

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
